### PR TITLE
fix variables names

### DIFF
--- a/vendor/iu-redcap/redcap-etl/src/Logger.php
+++ b/vendor/iu-redcap/redcap-etl/src/Logger.php
@@ -677,7 +677,7 @@ class Logger
         foreach ($mailToAddresses as $mailto) {
             $sent = mail($mailto, $subjectString, $message, $headers, $sendmailOpts);
             if ($sent === false) {
-                array_push($failedSentTos, $mailTo);
+                array_push($faliedSendTos, $mailto);
             }
         }
 


### PR DESCRIPTION
PHP 8.3 is complaining about misspelled variables $faliedSendTos, $mailto. 