### PR TITLE
Release 2.4.13: Security Patch for phpseclib

### DIFF
--- a/classes/Version.php
+++ b/classes/Version.php
@@ -13,5 +13,5 @@ namespace IU\RedCapEtlModule;
 class Version
 {
     # This release number should be updated each time a release is made.
-    public const RELEASE_NUMBER = "2.4.12";
+    public const RELEASE_NUMBER = "2.4.13";
 }


### PR DESCRIPTION
Security Fix: Upgraded phpseclib/phpseclib from 3.0.51 to 3.0.52 to address vulnerabilities.
Version Bump: Updated module version to 2.4.13.